### PR TITLE
fix: add publishConfig for npm publishing

### DIFF
--- a/.changeset/fix-npm-publish.md
+++ b/.changeset/fix-npm-publish.md
@@ -1,0 +1,16 @@
+---
+"@hugsy/plugin-docker": patch
+"@hugsy/plugin-git": patch
+"@hugsy/plugin-node": patch
+"@hugsy/plugin-python": patch
+"@hugsy/plugin-typescript": patch
+"@hugsy/plugin-test": patch
+"@hugsy/plugin-security": patch
+"@hugsy/commands-dev": patch
+"@hugsy/preset-recommended": patch
+---
+
+fix: Add publishConfig for npm publishing
+
+- Added `publishConfig.access: "public"` to all packages to enable npm publishing for scoped packages
+- This fixes the npm 404 error when publishing @hugsy scoped packages

--- a/packages/commands/dev/package.json
+++ b/packages/commands/dev/package.json
@@ -38,5 +38,8 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/docker/package.json
+++ b/packages/plugins/docker/package.json
@@ -40,5 +40,8 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/git/package.json
+++ b/packages/plugins/git/package.json
@@ -39,5 +39,8 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/node/package.json
+++ b/packages/plugins/node/package.json
@@ -41,5 +41,8 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/python/package.json
+++ b/packages/plugins/python/package.json
@@ -38,5 +38,8 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/security/package.json
+++ b/packages/plugins/security/package.json
@@ -39,5 +39,8 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/test/package.json
+++ b/packages/plugins/test/package.json
@@ -42,5 +42,8 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/plugins/typescript/package.json
+++ b/packages/plugins/typescript/package.json
@@ -39,5 +39,8 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/presets/recommended/package.json
+++ b/packages/presets/recommended/package.json
@@ -35,5 +35,8 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
- Add publishConfig.access: 'public' to all packages
- This enables npm publishing for @hugsy scoped packages
- Fixes npm 404 error during CI/CD publish

🤖 Generated with Claude Code