### PR TITLE
Fix CI badge URL typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Official plugin ecosystem for [Hugsy](https://github.com/HugsyLab/hugsy) - Configuration management for Claude Code.
 
-[![CI](https://github.com/HugsyLab/hugsy-plugins/actions/workflows/ci.yml/badge.svg)](https://github.com/HugsyLab/hugsy-plugins/actions/workflows/ci.yml)
+[![CI](https://github.com/HugsyLabs/hugsy-plugins/actions/workflows/ci.yml/badge.svg)](https://github.com/HugsyLabs/hugsy-plugins/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## 📦 Available Packages


### PR DESCRIPTION
Fix organization name from HugsyLab to HugsyLabs in CI badge URL

The CI is actually passing, but the badge wasn't showing correctly due to incorrect org name in the URL.