### PR TITLE
fix: add subagents to pnpm workspace configuration

### DIFF
--- a/.changeset/fix-workspace-subagents.md
+++ b/.changeset/fix-workspace-subagents.md
@@ -1,0 +1,9 @@
+---
+'@hugsylabs/subagent-security-engineer': patch
+---
+
+Fix workspace configuration to include subagents packages
+
+- Add packages/subagents/\* to pnpm workspace configuration
+- Ensures all subagent packages are properly recognized in the monorepo
+- Fixes CI/CD build issues with changeset version command

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ packages:
   - 'packages/plugins/*'
   - 'packages/commands/*'
   - 'packages/presets/*'
+  - 'packages/subagents/*'


### PR DESCRIPTION
## Summary
Fix CI/CD build failure by adding subagents packages to pnpm workspace configuration.

## Problem
The CI build was failing with error:
```
Error: Found changeset security-engineer-subagent for package @hugsylabs/subagent-security-engineer which is not in the workspace
```

## Solution
- ✅ Add `packages/subagents/*` to pnpm-workspace.yaml
- ✅ Ensures all subagent packages are properly recognized in the monorepo
- ✅ Fixes changeset version command in CI/CD pipeline

## Testing
- [x] Lint passes
- [x] Tests pass  
- [x] Build succeeds
- [x] Changeset properly detects the package

## Impact
This fix allows the security-engineer subagent (and future subagents) to be properly published through the CI/CD pipeline.

🤖 Generated with [Claude Code](https://claude.ai/code)